### PR TITLE
Fix - Replacing Unsupervised with SelfSupervised

### DIFF
--- a/jai/functions/classes.py
+++ b/jai/functions/classes.py
@@ -6,7 +6,7 @@ __all__ = ['FieldName', 'Mode', 'PossibleDtypes']
 class PossibleDtypes(str, Enum):
     image = "Image"
     fasttext = "FastText"
-    unsupervised = "Unsupervised"
+    selfsupervised = "SelfSupervised"
     supervised = "Supervised"
     text = "Text"
     edit = "TextEdit"

--- a/jai/functions/utils_funcs.py
+++ b/jai/functions/utils_funcs.py
@@ -96,11 +96,13 @@ def data2json(data, dtype):
                 )
         else:
             raise NotImplementedError(f"type {type(data)} is not implemented.")
-    elif dtype == PossibleDtypes.supervised or dtype == PossibleDtypes.unsupervised:
+    elif dtype == PossibleDtypes.supervised or dtype == PossibleDtypes.selfsupervised:
         if isinstance(data, pd.DataFrame):
             return df2json(data)
         else:
             raise NotImplementedError(f"type {type(data)} is not implemented.")
+    elif dtype == "Unsupervised":
+        raise ValueError(f"'Unsupervised' type has been replaced with {PossibleDtypes.selfsupervised} since version 0.6.0")
     else:
         raise ValueError(f"dtype {dtype} not recognized.")
 

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -76,7 +76,7 @@ class Jai:
         Example
         -------
         >>> j.names
-        ['jai_database', 'jai_unsupervised', 'jai_supervised']
+        ['jai_database', 'jai_selfsupervised', 'jai_supervised']
 
         """
         response = requests.get(url=self.url + "/info?mode=names",
@@ -104,10 +104,10 @@ class Jai:
         Example
         -------
         >>> j.info
-                                db_name       db_type
-        0                  jai_database          Text
-        1              jai_unsupervised  Unsupervised
-        2                jai_supervised    Supervised
+                                db_name           db_type
+        0                  jai_database              Text
+        1              jai_selfsupervised  SelfSupervised
+        2                jai_supervised        Supervised
         """
         response = requests.get(url=self.url + "/info?mode=complete",
                                 headers=self.header)
@@ -428,7 +428,7 @@ class Jai:
             Data to be checked and cleaned.
 
         db_type : str
-            Database type (Supervised, Unsupervised, Text...)
+            Database type (Supervised, SelfSupervised, Text...)
 
         Return
         ------
@@ -628,7 +628,7 @@ class Jai:
         name : str
             String with the name of a database in your JAI environment.
         db_type : str
-            Database type (Supervised, Unsupervised, Text...)
+            Database type (Supervised, SelSupervised, Text...)
         batch_size : int
             Size of batch to send the data.
 
@@ -687,7 +687,7 @@ class Jai:
         data : pandas.DataFrame or pandas.Series
             Data to be inserted and used for training.
         db_type : str
-            Database type {Supervised, Unsupervised, Text, FastText, TextEdit, Image}
+            Database type {Supervised, SelfSupervised, Text, FastText, TextEdit, Image}
         batch_size : int
             Size of batch to insert the data.`Default is 16384 (2**14)`.
         frequency_seconds : int
@@ -851,7 +851,7 @@ class Jai:
         Args
         ----
         db_type : str
-            Database type (Supervised, Unsupervised, Text...)
+            Database type (Supervised, SelfSupervised, Text...)
 
         Return
         ------
@@ -860,11 +860,11 @@ class Jai:
         """
         possible = ["hyperparams", "callback_url"]
         must = []
-        if db_type == "Unsupervised":
+        if db_type == PossibleDtypes.selfsupervised:
             possible.extend([
                 'num_process', 'cat_process', 'high_process', 'mycelia_bases'
             ])
-        elif db_type == "Supervised":
+        elif db_type == PossibleDtypes.supervised:
             possible.extend([
                 'num_process', 'cat_process', 'high_process', 'mycelia_bases',
                 'label', 'split'
@@ -899,7 +899,7 @@ class Jai:
         name : str
             String with the name of a database in your JAI environment.
         db_type : str
-            Database type (Supervised, Unsupervised, Text...)
+            Database type (Supervised, SelfSupervised, Text...)
         overwrite : bool
             [Optional] Whether of not to overwrite the given database. `Default is False`.
         **kwargs:
@@ -925,7 +925,7 @@ class Jai:
 
     def fields(self, name: str):
         """
-        Get the table fields for a Supervised/Unsupervised database.
+        Get the table fields for a Supervised/SelfSupervised database.
 
         Args
         ----
@@ -946,9 +946,9 @@ class Jai:
         {'id': 0, 'feature1': 0.01, 'feature2': 'string', 'feature3': 0}
         """
         dtype = self._get_dtype(name)
-        if dtype != "Unsupervised" and dtype != "Supervised":
+        if dtype != PossibleDtypes.selfsupervised and dtype != PossibleDtypes.supervised:
             raise ValueError(
-                "'fields' method is only available to dtype Unsupervised and Supervised."
+                "'fields' method is only available to dtype SelSupervised and Supervised."
             )
 
         response = requests.get(self.url + f"/table/fields/{name}",

--- a/jai/tests/test_zjai_models.py
+++ b/jai/tests/test_zjai_models.py
@@ -64,10 +64,10 @@ def test_text(name, data, dtype, setup_dataframe):
 
 
 # =============================================================================
-# Test Unsupervised
+# Test Self-supervised
 # =============================================================================
-def test_unsupervised(setup_dataframe):
-    name = 'test_unsupervised'
+def test_selfsupervised(setup_dataframe):
+    name = 'test_selfsupervised'
 
     train, _ = setup_dataframe
     train = train.drop(columns=["PassengerId"])
@@ -77,7 +77,7 @@ def test_unsupervised(setup_dataframe):
     if j.is_valid(name):
         j.delete_database(name)
 
-    j.setup(name, train, db_type="Unsupervised", overwrite=True)
+    j.setup(name, train, db_type="SelfSupervised", overwrite=True)
 
     assert j.is_valid(name), f"valid name {name} after setup failed"
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="jai-sdk",
-    version="0.6.0",
+    version="0.6.1",
     author="JQuant",
     author_email="jedis@jquant.com.br",
     description="JAI - Trust your data",


### PR DESCRIPTION
An informative error is now raised when an user tries to setup a database with `db_type=Unsupervised`.