### PR TITLE
Expanding preprocessing of sanity and fill

### DIFF
--- a/jai/jai.py
+++ b/jai/jai.py
@@ -1423,7 +1423,20 @@ class Jai:
             train = data.loc[~mask].copy()
             test = data.loc[mask].drop(columns=[column])
 
+            # first columns to include are the ones that satisfy
+            # the cat_threshold
             pre = cat.columns[cat.nunique() > cat_threshold].tolist()
+
+            # check if db_type is a dict and has some keys in it
+            # that do not satisfy the cat_threshold, but must be
+            # processed anyway
+            if isinstance(db_type, dict):
+                pre.extend([item for item in db_type.items() if item in cat.columns])
+            
+            # we make `pre` a set to ensure it has
+            # unique column names
+            pre = set(pre)
+
             prep_bases = []
 
             # check if database and column names will not overflow the 32-character
@@ -1569,7 +1582,20 @@ class Jai:
         cat = data.select_dtypes(exclude="number")
 
         if name not in self.names:
+            # first columns to include are the ones that satisfy
+            # the cat_threshold
             pre = cat.columns[cat.nunique() > cat_threshold].tolist()
+
+            # check if db_type is a dict and has some keys in it
+            # that do not satisfy the cat_threshold, but must be
+            # processed anyway
+            if isinstance(db_type, dict):
+                pre.extend([item for item in db_type.items() if item in cat.columns])
+            
+            # we make `pre` a set to ensure it has
+            # unique column names
+            pre = set(pre)
+            
             if columns_ref is None:
                 columns_ref = cat.columns.tolist()
             elif not isinstance(columns_ref, list):

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -1431,7 +1431,7 @@ class Jai:
             # that do not satisfy the cat_threshold, but must be
             # processed anyway
             if isinstance(db_type, dict):
-                pre.extend([item for item in db_type.items() if item in cat.columns])
+                pre.extend([item for item in db_type.keys() if item in cat.columns])
             
             # we make `pre` a set to ensure it has
             # unique column names
@@ -1590,12 +1590,12 @@ class Jai:
             # that do not satisfy the cat_threshold, but must be
             # processed anyway
             if isinstance(db_type, dict):
-                pre.extend([item for item in db_type.items() if item in cat.columns])
+                pre.extend([item for item in db_type.keys() if item in cat.columns])
             
             # we make `pre` a set to ensure it has
             # unique column names
             pre = set(pre)
-            
+
             if columns_ref is None:
                 columns_ref = cat.columns.tolist()
             elif not isinstance(columns_ref, list):

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -1431,8 +1431,9 @@ class Jai:
             # that do not satisfy the cat_threshold, but must be
             # processed anyway
             if isinstance(db_type, dict):
-                pre.extend([item for item in db_type.keys() if item in cat.columns])
-            
+                pre.extend(
+                    [item for item in db_type.keys() if item in cat.columns])
+
             # we make `pre` a set to ensure it has
             # unique column names
             pre = set(pre)
@@ -1589,8 +1590,9 @@ class Jai:
             # that do not satisfy the cat_threshold, but must be
             # processed anyway
             if isinstance(db_type, dict):
-                pre.extend([item for item in db_type.keys() if item in cat.columns])
-            
+                pre.extend(
+                    [item for item in db_type.keys() if item in cat.columns])
+
             # we make `pre` a set to ensure it has
             # unique column names
             pre = set(pre)


### PR DESCRIPTION
`sanity` and `fill` methods now include columns that are defined in the `db_type` parameter and DO NOT satisfy the category threshold for preprocessing