### PR TITLE
Improve interruption

### DIFF
--- a/jai/jai.py
+++ b/jai/jai.py
@@ -121,7 +121,7 @@ class Jai:
                     "db_version": "last modified",
                     "db_parents": "dependencies",
                 })
-            return df
+            return df.sort_values(by="name")
         else:
             return self.assert_status_code(response)
 
@@ -1036,8 +1036,9 @@ class Jai:
                     pbar.update(max_steps)
         except KeyboardInterrupt:
             print("\n\nInterruption caught!\n\n")
-            return requests.post(self.url + f"/cancel/{name}",
-                                 headers=self.header)
+            response = requests.post(self.url + f'/cancel/{name}', headers=self.header)
+            print(f"Cancel request status: {response.status_code}")
+            raise KeyboardInterrupt
 
         self._delete_status(name)
         return status

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -1038,7 +1038,7 @@ class Jai:
             print("\n\nInterruption caught!\n\n")
             response = requests.post(self.url + f'/cancel/{name}', headers=self.header)
             print(f"Cancel request status: {response.status_code}")
-            raise KeyboardInterrupt
+            raise KeyboardInterrupt(response.text)
 
         self._delete_status(name)
         return status


### PR DESCRIPTION
A `Ctrl+C` event now raises a KeyboardInterrupt instead of just returning a response of the `cancel` request from the API.