### PR TITLE
Feature/early stopping

### DIFF
--- a/docs/source/jai.rst
+++ b/docs/source/jai.rst
@@ -133,3 +133,9 @@ it were in the body of a POST method.
   * **type** (*str*) -- How to split the data in train and test {random, stratified}. *Default is "random"*.
   * **split_column** (*str*) -- (*Mandatory when type is stratified*) Name of column as reference for the split. *Default is ""*.
   * **test_size** (*float*) -- Size of test for the split. *Default is 0.2*.
+
+* **patience** (*int*) -- (Supervised and Self-Supervised only) Number of validation checks with no improvement after which training will be stopped.
+  *Default is 7*.
+
+* **min_delta** (*float*) -- (Supervised and Self-Supervised only) Minimum change in the monitored quantity (loss) to qualify as an improvement,
+  i.e. an absolute change of less than min_delta, will count as no improvement. *Default is 1e-5*.

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -889,13 +889,13 @@ class Jai:
                     print("Recognized setup args:")
                     flag = False
                 if key == "patience" and val < 1:
-                    val = 7  # default patience value
+                    val = 7  # default patience value for our purposes
                     print(
                         f"'patience' value must be greater than or equal to 1, but got {val} instead. Setting it to 7 (default)"
                     )
 
                 if key == "min_delta" and val < 0:
-                    val = 1e-5  # default min_delta value
+                    val = 1e-5  # default min_delta value for our purposes
                     print(
                         f"'min_delta' value must be greater than or equal to 0, but got {val} instead. Setting it to 1e-5 (default)"
                     )

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -867,12 +867,12 @@ class Jai:
         if db_type == PossibleDtypes.selfsupervised:
             possible.extend([
                 'num_process', 'cat_process', 'datetime_process',
-                'mycelia_bases'
+                'mycelia_bases', 'patience', 'min_delta'
             ])
         elif db_type == PossibleDtypes.supervised:
             possible.extend([
                 'num_process', 'cat_process', 'datetime_process',
-                'mycelia_bases', 'label', 'split'
+                'mycelia_bases', 'label', 'split', 'patience', 'min_delta'
             ])
             must.extend(['label'])
 
@@ -888,6 +888,14 @@ class Jai:
                 if flag:
                     print("Recognized setup args:")
                     flag = False
+                if key == "patience" and val < 1:
+                    val = 7 # default patience value
+                    print(f"'patience' value must be greater than or equal to 1, but got {val} instead. Setting it to 7 (default)")
+
+                if key == "min_delta" and val < 0:
+                    val = 1e-5 # default min_delta value
+                    print(f"'min_delta' value must be greater than or equal to 0, but got {val} instead. Setting it to 1e-5 (default)")
+
                 print(f"{key}: {val}")
                 body[key] = val
 
@@ -1016,8 +1024,12 @@ class Jai:
                                 status = self.status[name]
                             # training might stop early, so we make the progress bar appear
                             # full when early stopping is reached -- peace of mind
+                            last_n = iteration_bar.n
                             iteration_bar.update(max_iterations -
                                                  iteration_bar.n)
+                            if last_n != max_iterations:
+                                print("Early stopping reached.")
+                            
 
                     if (step == starts_at) and (aux == 0):
                         pbar.update(starts_at)

--- a/jai/tests/test_zjai_models.py
+++ b/jai/tests/test_zjai_models.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 import pytest
 
-URL = 'http://23.96.99.211:8001'
+URL = 'http://localhost:8001'
 AUTH_KEY = "sdk_test"
 
 np.random.seed(42)

--- a/jai/tests/test_zjai_models.py
+++ b/jai/tests/test_zjai_models.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 import pytest
 
-URL = 'http://localhost:8001'
+URL = 'http://23.96.99.211:8001'
 AUTH_KEY = "sdk_test"
 
 np.random.seed(42)


### PR DESCRIPTION
Exposing early stopping parameters to users. In `setup` method, params `patience` and `min_delta` can now be passed as arguments.