### PR TITLE
Fix fill

### DIFF
--- a/jai/functions/utils_funcs.py
+++ b/jai/functions/utils_funcs.py
@@ -102,7 +102,7 @@ def data2json(data, dtype, predict=False):
                 return df2json(data)
             else:
                 raise ValueError(
-                    f"Data must be a DataFrame with at least 2 columns other than 'id'. Current column(s):\n{data.columns}"
+                    f"Data must be a DataFrame with at least 2 columns other than 'id'. Current column(s):\n{data.columns.tolist()}"
                 )
         else:
             raise NotImplementedError(f"type {type(data)} is not implemented.")
@@ -113,7 +113,7 @@ def data2json(data, dtype, predict=False):
                 return df2json(data)
             else:
                 raise ValueError(
-                    f"Data must be a DataFrame with at least {2 - predict} column(s) other than 'id'. Current column(s):\n{data.columns}"
+                    f"Data must be a DataFrame with at least {2 - predict} column(s) other than 'id'. Current column(s):\n{data.columns.tolist()}"
                 )
         else:
             raise NotImplementedError(f"type {type(data)} is not implemented.")

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -532,7 +532,7 @@ class Jai:
             raise ValueError(
                 f"data must be a pandas Series or DataFrame. (data type {type(data)})"
             )
-        print("[DEBUG] - Inside predict")
+        
         results = []
         for i in trange(0, len(data), batch_size, desc="Predict"):
             _batch = data.iloc[i:i + batch_size]

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -532,7 +532,7 @@ class Jai:
             raise ValueError(
                 f"data must be a pandas Series or DataFrame. (data type {type(data)})"
             )
-
+        print("[DEBUG] - Inside predict")
         results = []
         for i in trange(0, len(data), batch_size, desc="Predict"):
             _batch = data.iloc[i:i + batch_size]
@@ -757,7 +757,8 @@ class Jai:
                  name: str,
                  data,
                  batch_size: int = 16384,
-                 frequency_seconds: int = 10):
+                 frequency_seconds: int = 10,
+                 predict: bool = False):
         """
         Insert raw data and extract their latent representation.
 
@@ -795,7 +796,8 @@ class Jai:
         insert_responses = self._insert_data(data=data,
                                              name=name,
                                              batch_size=batch_size,
-                                             db_type=db_type)
+                                             db_type=db_type,
+                                             predict=predict)
 
         # check if we inserted everything we were supposed to
         self._check_ids_consistency(name=name, data=data)
@@ -830,7 +832,7 @@ class Jai:
         else:
             return self.assert_status_code(response)
 
-    def _insert_data(self, data, name, db_type, batch_size):
+    def _insert_data(self, data, name, db_type, batch_size, predict=False):
         """
         Insert raw data for training. This is a protected method.
 
@@ -854,7 +856,7 @@ class Jai:
                 trange(0, len(data), batch_size, desc="Insert Data")):
             _batch = data.iloc[b:b + batch_size]
             insert_responses[i] = self._insert_json(
-                name, data2json(_batch, dtype=db_type))
+                name, data2json(_batch, dtype=db_type, predict=predict))
         return insert_responses
 
     def _insert_json(self, name: str, df_json):
@@ -1554,7 +1556,7 @@ class Jai:
         ids_test = test.index
         missing_test = ids_test[~np.isin(ids_test, self.ids(name, "complete"))]
         if len(missing_test) > 0:
-            self.add_data(name, test.loc[missing_test])
+            self.add_data(name, test.loc[missing_test], predict=True)
 
         return self.predict(name, test, predict_proba=True)
 

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -532,7 +532,7 @@ class Jai:
             raise ValueError(
                 f"data must be a pandas Series or DataFrame. (data type {type(data)})"
             )
-        
+
         results = []
         for i in trange(0, len(data), batch_size, desc="Predict"):
             _batch = data.iloc[i:i + batch_size]


### PR DESCRIPTION
Added `predict` argument to `add_data` method and set it to `True` when running `fill`. The application should now run even when there is only one column other than the label in one's dataframe.

Fixes #167 