### PR TITLE
Minor fix - floor in stratified sampling

### DIFF
--- a/jai/jai.py
+++ b/jai/jai.py
@@ -1708,7 +1708,7 @@ class Jai:
                     except:
                         pass
 
-                    if len(indexes) < data.shape[0] * frac:
+                    if len(indexes) < int(np.floor(data.shape[0] * frac)):
                         s = data.sample(frac=frac)
 
                     uniques = s[c].unique()


### PR DESCRIPTION
Minor correction. Compare number of extracted samples to `floor(len(data) * frac)` instead of `len(data) * frac` to decide whether or not the stratified sampling worked.