### PR TITLE
Feature/max epochs

### DIFF
--- a/jai/jai.py
+++ b/jai/jai.py
@@ -927,22 +927,19 @@ class Jai:
                     flag = False
 
                 if key == "hyperparams":
-                    if "patience" in val and val[
-                            "patience"] < 1:
+                    if "patience" in val and val["patience"] < 1:
                         val["patience"] = 7  # default patience value for our purposes
                         print(
                             f"'patience' value must be greater than or equal to 1, but got {val['patience']} instead. Setting it to 7 (default)"
                         )
 
-                    if "min_delta" in val and val[
-                            "min_delta"] < 0:
+                    if "min_delta" in val and val["min_delta"] < 0:
                         val["min_delta"] = 1e-5  # default min_delta value for our purposes
                         print(
                             f"'min_delta' value must be greater than or equal to 0, but got {val['min_delta']} instead. Setting it to 1e-5 (default)"
                         )
 
-                    if "max_epochs" in val and val[
-                            "max_epochs"] < 1:
+                    if "max_epochs" in val and val["max_epochs"] < 1:
                         val["max_epochs"] = 100  # default max_epochs value for our purposes
                         print(
                             f"'max_epochs' value must be greater than or equal to 1, but got {val['max_epochs']} instead. Setting it to 100 (default)"

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -925,20 +925,23 @@ class Jai:
                 if flag:
                     print("Recognized setup args:")
                     flag = False
-                
-                if key == "hyperparams" and "patience" in val and val["patience"] < 1:
+
+                if key == "hyperparams" and "patience" in val and val[
+                        "patience"] < 1:
                     val["patience"] = 7  # default patience value for our purposes
                     print(
                         f"'patience' value must be greater than or equal to 1, but got {val['patience']} instead. Setting it to 7 (default)"
                     )
 
-                if key == "hyperparams" and "min_delta" in val and val["min_delta"] < 0:
+                if key == "hyperparams" and "min_delta" in val and val[
+                        "min_delta"] < 0:
                     val["min_delta"] = 1e-5  # default min_delta value for our purposes
                     print(
                         f"'min_delta' value must be greater than or equal to 0, but got {val['min_delta']} instead. Setting it to 1e-5 (default)"
                     )
 
-                if key == "hyperparams" and "max_epochs" in val and val["max_epochs"] < 1:
+                if key == "hyperparams" and "max_epochs" in val and val[
+                        "max_epochs"] < 1:
                     val["max_epochs"] = 100  # default max_epochs value for our purposes
                     print(
                         f"'max_epochs' value must be greater than or equal to 1, but got {val['max_epochs']} instead. Setting it to 100 (default)"

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -928,9 +928,9 @@ class Jai:
 
                 if key == "hyperparams":
                     if "patience" in val and val["patience"] < 1:
-                        val["patience"] = 7  # default patience value for our purposes
+                        val["patience"] = 10  # default patience value for our purposes
                         print(
-                            f"'patience' value must be greater than or equal to 1, but got {val['patience']} instead. Setting it to 7 (default)"
+                            f"'patience' value must be greater than or equal to 1, but got {val['patience']} instead. Setting it to 10 (default)"
                         )
 
                     if "min_delta" in val and val["min_delta"] < 0:
@@ -940,9 +940,9 @@ class Jai:
                         )
 
                     if "max_epochs" in val and val["max_epochs"] < 1:
-                        val["max_epochs"] = 100  # default max_epochs value for our purposes
+                        val["max_epochs"] = 500  # default max_epochs value for our purposes
                         print(
-                            f"'max_epochs' value must be greater than or equal to 1, but got {val['max_epochs']} instead. Setting it to 100 (default)"
+                            f"'max_epochs' value must be greater than or equal to 1, but got {val['max_epochs']} instead. Setting it to 500 (default)"
                         )
 
                 print(f"{key}: {val}")

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -925,16 +925,23 @@ class Jai:
                 if flag:
                     print("Recognized setup args:")
                     flag = False
-                if key == "patience" and val < 1:
-                    val = 7  # default patience value for our purposes
+                
+                if key == "hyperparams" and "patience" in val and val["patience"] < 1:
+                    val["patience"] = 7  # default patience value for our purposes
                     print(
-                        f"'patience' value must be greater than or equal to 1, but got {val} instead. Setting it to 7 (default)"
+                        f"'patience' value must be greater than or equal to 1, but got {val['patience']} instead. Setting it to 7 (default)"
                     )
 
-                if key == "min_delta" and val < 0:
-                    val = 1e-5  # default min_delta value for our purposes
+                if key == "hyperparams" and "min_delta" in val and val["min_delta"] < 0:
+                    val["min_delta"] = 1e-5  # default min_delta value for our purposes
                     print(
-                        f"'min_delta' value must be greater than or equal to 0, but got {val} instead. Setting it to 1e-5 (default)"
+                        f"'min_delta' value must be greater than or equal to 0, but got {val['min_delta']} instead. Setting it to 1e-5 (default)"
+                    )
+
+                if key == "hyperparams" and "max_epochs" in val and val["max_epochs"] < 1:
+                    val["max_epochs"] = 100  # default max_epochs value for our purposes
+                    print(
+                        f"'max_epochs' value must be greater than or equal to 1, but got {val['max_epochs']} instead. Setting it to 100 (default)"
                     )
 
                 print(f"{key}: {val}")

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -926,26 +926,27 @@ class Jai:
                     print("Recognized setup args:")
                     flag = False
 
-                if key == "hyperparams" and "patience" in val and val[
-                        "patience"] < 1:
-                    val["patience"] = 7  # default patience value for our purposes
-                    print(
-                        f"'patience' value must be greater than or equal to 1, but got {val['patience']} instead. Setting it to 7 (default)"
-                    )
+                if key == "hyperparams":
+                    if "patience" in val and val[
+                            "patience"] < 1:
+                        val["patience"] = 7  # default patience value for our purposes
+                        print(
+                            f"'patience' value must be greater than or equal to 1, but got {val['patience']} instead. Setting it to 7 (default)"
+                        )
 
-                if key == "hyperparams" and "min_delta" in val and val[
-                        "min_delta"] < 0:
-                    val["min_delta"] = 1e-5  # default min_delta value for our purposes
-                    print(
-                        f"'min_delta' value must be greater than or equal to 0, but got {val['min_delta']} instead. Setting it to 1e-5 (default)"
-                    )
+                    if "min_delta" in val and val[
+                            "min_delta"] < 0:
+                        val["min_delta"] = 1e-5  # default min_delta value for our purposes
+                        print(
+                            f"'min_delta' value must be greater than or equal to 0, but got {val['min_delta']} instead. Setting it to 1e-5 (default)"
+                        )
 
-                if key == "hyperparams" and "max_epochs" in val and val[
-                        "max_epochs"] < 1:
-                    val["max_epochs"] = 100  # default max_epochs value for our purposes
-                    print(
-                        f"'max_epochs' value must be greater than or equal to 1, but got {val['max_epochs']} instead. Setting it to 100 (default)"
-                    )
+                    if "max_epochs" in val and val[
+                            "max_epochs"] < 1:
+                        val["max_epochs"] = 100  # default max_epochs value for our purposes
+                        print(
+                            f"'max_epochs' value must be greater than or equal to 1, but got {val['max_epochs']} instead. Setting it to 100 (default)"
+                        )
 
                 print(f"{key}: {val}")
                 body[key] = val

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="jai-sdk",
-    version="0.8.1",
+    version="0.9.0",
     author="JQuant",
     author_email="jedis@jquant.com.br",
     description="JAI - Trust your data",


### PR DESCRIPTION
Users can now set the number of epochs using `hyperparams` on `setup` calls. Also, `patience` and `min_delta` moved to `hyperparams` as well. So instead of `j.setup(db_name, data, patience=7, min_delta=0.0001)` users can now use `j.setup(db_name, data, hyperparams={'patience': 7, 'min_delta': 0.0001, 'max_epochs': 200})`