### PR TITLE
Column name

### DIFF
--- a/jai/functions/utils_funcs.py
+++ b/jai/functions/utils_funcs.py
@@ -47,10 +47,9 @@ def list2json(data_list, name):
     return series.reset_index().to_json(orient='records', date_format="iso")
 
 
-def series2json(data_series, name):
+def series2json(data_series):
     data_series = data_series.copy()
     data_series.index.name = 'id'
-    data_series.name = name
     if data_series.index.duplicated().any():
         raise ValueError("Index must not contain duplicated values.")
     return data_series.reset_index().to_json(orient='records',
@@ -71,27 +70,25 @@ def data2json(data, dtype, filter_name=None, predict=False):
     if (dtype == PossibleDtypes.edit or dtype == PossibleDtypes.text
             or dtype == PossibleDtypes.fasttext
             or dtype == PossibleDtypes.image):
-        if dtype == PossibleDtypes.image:
-            name = FieldName.image
-        else:
-            name = FieldName.text
+        name = FieldName.image if dtype == PossibleDtypes.image else FieldName.text
+
         if isinstance(data, (set, list, tuple, np.ndarray)):
             return list2json(data, name=name)
         elif isinstance(data, pd.Series):
-            return series2json(data, name=name)
+            return series2json(data)
         elif isinstance(data, pd.DataFrame):
             if data.shape[1] == 1:
                 c = data.columns[0]
-                return series2json(data[c], name=name)
+                return series2json(data[c])
             elif data.shape[1] == 2:
                 if 'id' in data.columns:
                     data = data.set_index('id')
                     c = data.columns[0]
-                    return series2json(data[c], name=name)
+                    return series2json(data[c])
                 elif filter_name in data.columns:
                     cols = data.columns.tolist()
                     cols.remove(filter_name)
-                    return df2json(data.rename(columns={cols[0]: name}))
+                    return df2json(data)
                 else:
                     raise ValueError(
                         "If data has 2 columns, one must be named 'id'.")
@@ -100,7 +97,7 @@ def data2json(data, dtype, filter_name=None, predict=False):
                     data = data.set_index('id')
                     cols = data.columns.tolist()
                     cols.remove(filter_name)
-                    return df2json(data.rename(columns={cols[0]: name}))
+                    return df2json(data)
                 else:
                     raise ValueError(
                         "If data has 2 columns, one must be named 'id'.")

--- a/jai/functions/utils_funcs.py
+++ b/jai/functions/utils_funcs.py
@@ -62,8 +62,8 @@ def df2json(dataframe):
 
 def data2json(data, dtype, filter_name=None, predict=False):
     if dtype in [
-            PossibleDtypes.edit, dtype == PossibleDtypes.text,
-            PossibleDtypes.fasttext, PossibleDtypes.image
+            PossibleDtypes.edit, PossibleDtypes.text, PossibleDtypes.fasttext,
+            PossibleDtypes.image
     ]:
         if isinstance(data, (set, list, tuple, np.ndarray)):
             raise TypeError(

--- a/jai/functions/utils_funcs.py
+++ b/jai/functions/utils_funcs.py
@@ -41,12 +41,6 @@ def pbar_steps(status: List = None, step: int = 0):
         return step, None
 
 
-def list2json(data_list, name):
-    index = pd.Index(range(len(data_list)), name='id')
-    series = pd.Series(data_list, index=index, name=name)
-    return series.reset_index().to_json(orient='records', date_format="iso")
-
-
 def series2json(data_series):
     data_series = data_series.copy()
     data_series.index.name = 'id'
@@ -67,13 +61,14 @@ def df2json(dataframe):
 
 
 def data2json(data, dtype, filter_name=None, predict=False):
-    if (dtype == PossibleDtypes.edit or dtype == PossibleDtypes.text
-            or dtype == PossibleDtypes.fasttext
-            or dtype == PossibleDtypes.image):
-        name = FieldName.image if dtype == PossibleDtypes.image else FieldName.text
-
+    if dtype in [
+            PossibleDtypes.edit, dtype == PossibleDtypes.text,
+            PossibleDtypes.fasttext, PossibleDtypes.image
+    ]:
         if isinstance(data, (set, list, tuple, np.ndarray)):
-            return list2json(data, name=name)
+            raise TypeError(
+                "dtypes `set`, `list`, `tuple`, `np.ndarray` have been deprecated. Use pd.Series instead."
+            )
         elif isinstance(data, pd.Series):
             return series2json(data)
         elif isinstance(data, pd.DataFrame):
@@ -107,7 +102,7 @@ def data2json(data, dtype, filter_name=None, predict=False):
                 )
         else:
             raise NotImplementedError(
-                f"type `{data.__class__.__name__}` is not implemented.")
+                f"type `{data.__class__.__name__}` is not accepted.")
     elif dtype == PossibleDtypes.selfsupervised:
         if isinstance(data, pd.DataFrame):
             if (data.columns != 'id').sum() >= 2:

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -674,16 +674,16 @@ class Jai(BaseJai):
         body: dict
             Body to be sent in the POST request to the API.
         """
-        possible = ["hyperparams", "callback_url"]
+        possible = ["hyperparams", "callback_url", "features"]
         must = []
         if db_type == PossibleDtypes.selfsupervised:
             possible.extend([
-                'num_process', 'cat_process', 'datetime_process', 'features',
+                'num_process', 'cat_process', 'datetime_process',
                 'mycelia_bases'
             ])
         elif db_type == PossibleDtypes.supervised:
             possible.extend([
-                'num_process', 'cat_process', 'datetime_process', 'features',
+                'num_process', 'cat_process', 'datetime_process',
                 'mycelia_bases', 'label', 'split'
             ])
             must.extend(['label'])

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -324,7 +324,9 @@ class Jai(BaseJai):
                 else:
                     _batch = data[i:i + batch_size]
                 res = self._similar_json(name,
-                                         data2json(_batch, dtype=dtype),
+                                         data2json(_batch,
+                                                   dtype=dtype,
+                                                   predict=True),
                                          top_k=top_k,
                                          filters=filters)
             results.extend(res["similarity"])
@@ -549,8 +551,7 @@ class Jai(BaseJai):
                  data,
                  batch_size: int = 16384,
                  frequency_seconds: int = 1,
-                 filter_name: str = None,
-                 predict: bool = False):
+                 filter_name: str = None):
         """
         Insert raw data and extract their latent representation.
 
@@ -568,9 +569,6 @@ class Jai(BaseJai):
             Size of batch to send the data. `Default is 16384`.
         frequency_seconds : int
             Time in between each check of status. `Default is 10`.
-        predict : bool
-            Allows table type data to have only one column for predictions,
-            if False, then tables must have at least 2 columns. `Default is False`.
 
         Return
         -------
@@ -593,7 +591,7 @@ class Jai(BaseJai):
                                              batch_size=batch_size,
                                              db_type=db_type,
                                              filter_name=filter_name,
-                                             predict=predict)
+                                             predict=True)
 
         # check if we inserted everything we were supposed to
         self._check_ids_consistency(name=name, data=data)

--- a/jai/jai.py
+++ b/jai/jai.py
@@ -609,7 +609,7 @@ class Jai(BaseJai):
                data,
                batch_size: int = 16384,
                frequency_seconds: int = 1,
-               predict: bool = False):
+               filter_name: str = None):
         """
         Another name for add_data
         """
@@ -617,7 +617,7 @@ class Jai(BaseJai):
                              data=data,
                              batch_size=batch_size,
                              frequency_seconds=frequency_seconds,
-                             predict=predict)
+                             filter_name=filter_name)
 
     def _insert_data(self,
                      data,
@@ -674,17 +674,17 @@ class Jai(BaseJai):
         body: dict
             Body to be sent in the POST request to the API.
         """
-        possible = ["hyperparams", "callback_url", "features"]
+        possible = ["hyperparams", "callback_url"]
         must = []
         if db_type == PossibleDtypes.selfsupervised:
             possible.extend([
                 'num_process', 'cat_process', 'datetime_process',
-                'mycelia_bases'
+                'mycelia_bases', "features"
             ])
         elif db_type == PossibleDtypes.supervised:
             possible.extend([
                 'num_process', 'cat_process', 'datetime_process',
-                'mycelia_bases', 'label', 'split'
+                'mycelia_bases', "features", 'label', 'split'
             ])
             must.extend(['label'])
 
@@ -1453,10 +1453,7 @@ class Jai(BaseJai):
         ids_test = test.index
         missing_test = ids_test[~np.isin(ids_test, self.ids(name, "complete"))]
         if len(missing_test) > 0:
-            self.add_data(name,
-                          test.loc[missing_test],
-                          predict=True,
-                          batch_size=batch_size)
+            self.add_data(name, test.loc[missing_test], batch_size=batch_size)
 
         return self.predict(name,
                             test,

--- a/jai/preprocessing.py
+++ b/jai/preprocessing.py
@@ -26,12 +26,12 @@ def split(dataframe, columns):
     """
     dataframe = dataframe.copy()
     if isinstance(columns, str):
-        loop = {columns: None}
+        columns = {columns: None}
     elif isinstance(columns, list):
-        loop = {col: None for col in columns}
+        columns = {col: None for col in columns}
 
     bases = []
-    for col, sep in loop.items():
+    for col, sep in columns.items():
         if sep is not None:
             values = dataframe[col].str.split(sep).explode().str.strip()
         else:

--- a/jai/preprocessing.py
+++ b/jai/preprocessing.py
@@ -1,5 +1,7 @@
 import pandas as pd
 
+__all__ = ["split"]
+
 
 def split(dataframe, columns, sort: bool = False, prefix: str = "id_"):
     """

--- a/jai/preprocessing.py
+++ b/jai/preprocessing.py
@@ -1,0 +1,48 @@
+import pandas as pd
+
+
+def split(dataframe, columns):
+    """
+    Split columns from dataframe returning a dataframe with the unique values
+    for each specified column and replacing the original column with the
+    corresponding index of the new dataframe
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        Dataframe to be factored.
+    columns : str, list of str or dict, optional
+        Column to be separated from dataset.
+        If column has multiple data, use a dict with the format column name as
+        key and separator as value. Use `None` if no separator is needed.
+
+    Returns
+    -------
+    bases : list of pd.DataFrame
+        list of dataframes with each base extracted.
+    dataframe : pd.DataFrame
+        original dataframe with columns replaced by the ids of the correlated base.
+
+    """
+    dataframe = dataframe.copy()
+    if isinstance(columns, str):
+        loop = {columns: None}
+    elif isinstance(columns, list):
+        loop = {col: None for col in columns}
+
+    bases = []
+    for col, sep in loop.items():
+        if sep is not None:
+            values = dataframe[col].str.split(sep).explode().str.strip()
+        else:
+            values = dataframe[col]
+        ids, uniques = pd.factorize(values)
+        dataframe[col] = pd.DataFrame({
+            "id": values.index,
+            col: ids
+        }).groupby("id")[col].agg(lambda x: x if len(x) < 2 else list(x))
+        base = pd.DataFrame({col: uniques},
+                            index=pd.Index(range(len(uniques)), name="id"))
+        bases.append(base)
+
+    return bases, dataframe

--- a/jai/tests/test_utils.py
+++ b/jai/tests/test_utils.py
@@ -2,8 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from jai import Jai
-from jai.functions.utils_funcs import (list2json, series2json, df2json,
-                                       data2json)
+from jai.functions.utils_funcs import (series2json, df2json, data2json)
 from jai.image import read_image_folder, resize_image_folder
 
 from pandas._testing import assert_series_equal
@@ -39,15 +38,6 @@ def setup_npy_file():
 # =============================================================================
 # Tests for data2json
 # =============================================================================
-@pytest.mark.parametrize('data', [list('ab'), np.array(['abc', 'def'])])
-@pytest.mark.parametrize('name', ['text', 'image_base64'])
-def test_list2json(data, name):
-    index = pd.Index(range(len(data)), name='id')
-    gab = pd.Series(data, index=index,
-                    name=name).reset_index().to_json(orient='records')
-    assert list2json(data, name) == gab, 'list2json failed.'
-
-
 @pytest.mark.parametrize('data', [list('ab'), np.array(['abc', 'def'])])
 @pytest.mark.parametrize('name', ['text', 'image_base64'])
 @pytest.mark.parametrize('ids', [None, [10, 12]])

--- a/jai/tests/test_utils.py
+++ b/jai/tests/test_utils.py
@@ -62,7 +62,7 @@ def test_df2json(col1, col2, ids):
     assert df2json(df) == '[' + out + ']', 'df2json failed.'
 
 
-@pytest.mark.parametrize("dtype", ["list", "array", "series", "df", "df_id"])
+@pytest.mark.parametrize("dtype", ["series", "df", "df_id"])
 def test_data2json(setup_dataframe, setup_img_data, dtype):
     dict_dbtype = {"Text": "text", "Image": "image_base64"}
     db_types = ["Text", "Image"]
@@ -80,17 +80,7 @@ def test_data2json(setup_dataframe, setup_img_data, dtype):
         else:
             data = img_data
 
-        if dtype == 'list':
-            data = data.tolist()
-            ids = range(len(data))
-            s = pd.Series(data, index=pd.Index(ids, name='id'), name=col_name)
-            gab = s.reset_index().to_json(orient='records')
-        elif dtype == 'array':
-            data = data.values
-            ids = range(len(data))
-            s = pd.Series(data, index=pd.Index(ids, name='id'), name=col_name)
-            gab = s.reset_index().to_json(orient='records')
-        elif dtype == 'df':
+        if dtype == 'df':
             data = data.to_frame()
             ids = data.index
             s = pd.Series(data[col_name],

--- a/jai/tests/test_utils.py
+++ b/jai/tests/test_utils.py
@@ -158,7 +158,7 @@ def test_series_error(data, name, ids):
     with pytest.raises(ValueError):
         ids = ids if ids is not None else range(len(data))
         s = pd.Series(data, index=pd.Index(ids, name='id'), name=name)
-        series2json(s, name)
+        series2json(s)
 
 
 @pytest.mark.parametrize('col1, col2, ids',

--- a/jai/tests/test_utils.py
+++ b/jai/tests/test_utils.py
@@ -55,7 +55,7 @@ def test_series2json(data, name, ids):
     ids = ids if ids is not None else range(len(data))
     s = pd.Series(data, index=pd.Index(ids, name='id'), name=name)
     gab = s.reset_index().to_json(orient='records')
-    assert series2json(s, name) == gab, 'series2json failed.'
+    assert series2json(s) == gab, 'series2json failed.'
 
 
 @pytest.mark.parametrize('col1, col2, ids',

--- a/jai/tests/test_zjai_models.py
+++ b/jai/tests/test_zjai_models.py
@@ -49,9 +49,6 @@ def test_text(name, data, dtype, setup_dataframe):
     result = j.similar(name, query)
     assert isinstance(result, list), "similar data result failed"
 
-    result = j.similar(name, query.to_numpy())
-    assert isinstance(result, list), "similar data (np.array) result failed"
-
     result = j.similar(name, pd.Series(query.index))
     assert isinstance(result, list), "similar id series result failed"
 

--- a/jai/tests/test_zjai_models.py
+++ b/jai/tests/test_zjai_models.py
@@ -14,10 +14,9 @@ np.random.seed(42)
 # =============================================================================
 # Test Text
 # =============================================================================
-@pytest.mark.parametrize("name,data,dtype",
-                         [("test_nlp", "list", "Text"),
-                          ("test_fasttext", "array", "FastText"),
-                          ("test_edittext", "series", "TextEdit")])
+@pytest.mark.parametrize("name,dtype", [("test_nlp", "Text"),
+                                        ("test_fasttext", "FastText"),
+                                        ("test_edittext", "TextEdit")])
 def test_text(name, data, dtype, setup_dataframe):
     train, _ = setup_dataframe
     train = train.rename(columns={
@@ -25,15 +24,6 @@ def test_text(name, data, dtype, setup_dataframe):
     }).set_index("id")['Name'].iloc[:MAX_SIZE]
     ids = train.index.tolist()
     query = train.loc[np.random.choice(ids, 10, replace=False)]
-
-    if data == 'list':
-        train = train.tolist()
-        ids = list(range(len(train)))
-    elif data == 'array':
-        train = train.values
-        ids = list(range(len(train)))
-    else:
-        pass
 
     j = Jai(url=URL, auth_key=AUTH_KEY)
     if j.is_valid(name):

--- a/jai/tests/test_zjai_models.py
+++ b/jai/tests/test_zjai_models.py
@@ -17,7 +17,7 @@ np.random.seed(42)
 @pytest.mark.parametrize("name,dtype", [("test_nlp", "Text"),
                                         ("test_fasttext", "FastText"),
                                         ("test_edittext", "TextEdit")])
-def test_text(name, data, dtype, setup_dataframe):
+def test_text(name, dtype, setup_dataframe):
     train, _ = setup_dataframe
     train = train.rename(columns={
         "PassengerId": "id"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy==1.21.0
-pandas==1.3.0
-tqdm==4.61.2
+numpy>=1.21.0
+pandas>=1.3.0
+tqdm>=4.61.2
 pillow==8.3.1
-matplotlib==3.4.2
-scikit-learn==0.24.2
+matplotlib>=3.4.2
+scikit-learn>=0.24.2
 sphinx_rtd_theme==0.5.2


### PR DESCRIPTION
- Usage of data as list or np.array has been deprecated, list of ids on similarity is still accepted.
- Series names are used on setup of  Text, TextEdit, FastText and Image. The same name should be used on inference (similarity, add data and predict) even when the collection is used as a preprocessed base.
- Changed requirements
- Added jai.preprocessing.split function to split columns from DataFrames and do the id mapping.